### PR TITLE
#127 Add CONTRIBUTING guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,32 @@
+# Contributing
+
+[![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=flat-square)](http://makeapullrequest.com)
+
+The Community Health Toolkit is powered by people like you. Your contributions help us create open source technology for a new model of healthcare that reaches everyone.
+
+## Communication
+
+We recommend you raise an issue on Github or start a conversation on our [Community Forum](https://forum.communityhealthtoolkit.org) about the change you want to make before you start on code. Our Community Forum is especially helpful if you are a new contributor or find yourself unsure how to move forward with an issue.
+
+## Submitting code
+
+> We recommend you raise an issue on Github or start a conversation on our [Community Forum](https://forum.communityhealthtoolkit.org) about the change you want to make before you start on code.
+
+- Read our [Development Workflow](https://docs.communityhealthtoolkit.org/contribute/code/workflow/) to understand how we work, and review our [Code Style Guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/) before you begin.
+  - Note that the "Project States" section does not apply to changes made to `cht-conf-test-harness` 
+- Make the code change.
+  - Include tests for any new/updated logic.
+    - Include the issue/PR number in the test title. This provides context for future debugging if the test ever regresses.
+  - Update the project's version number in the [package.json](./package.json) by running `npm version <major|minor|patch>`
+- Before you submit a pull request, please make sure your contribution passes all tests. Test failures need to be addressed before we can merge your contribution.
+  - You can run `npm run travis` to build the project, lint the source code, and execute the tests.
+- Provide detail about the issue you are solving in the pull request description. Note: If your pull request addresses a specific issue, please reference it using medic/<repo>#<issue number>
+- Our CI will automatically schedule a build; monitor the build to ensure it passes.
+- Your PR will be reviewed by one of the repository's maintainers. Most PRs have at least one change requested before they're merged so don't be offended if your change doesn't get accepted on the first try!
+
+### Code of Conduct
+
+All maintainers and contributors are required to act according to our [Code of Conduct](https://github.com/medic/cht-core/blob/master/CODE_OF_CONDUCT.md). Thank you for your help building a positive community and a safe environment for everyone.
+
+#### License
+The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,10 +4,6 @@
 
 The Community Health Toolkit is powered by people like you. Your contributions help us create open source technology for a new model of healthcare that reaches everyone.
 
-## Communication
-
-We recommend you raise an issue on Github or start a conversation on our [Community Forum](https://forum.communityhealthtoolkit.org) about the change you want to make before you start on code. Our Community Forum is especially helpful if you are a new contributor or find yourself unsure how to move forward with an issue.
-
 ## Submitting code
 
 > We recommend you raise an issue on Github or start a conversation on our [Community Forum](https://forum.communityhealthtoolkit.org) about the change you want to make before you start on code.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ View the documentation [here](http://docs.communityhealthtoolkit.org/cht-conf-te
 
 ## Contributing
 
-At Medic we are the technical steward of the [Community Health Toolkit](https://communityhealthtoolkit.org) (CHT). We welcome and appreciate contributions, and support new developers to use the tools whenever possible. If you have an idea or a question we'd love to hear from you! The easiest ways to get in touch are by raising issues in the [medic Github repo](https://github.com/medic/cht-core/issues) or [joining our Slack channel](https://communityhealthtoolkit.org/slack). For more info check out our [contributor guidelines](CONTRIBUTING.md).
+At Medic we are the technical steward of the [Community Health Toolkit](https://communityhealthtoolkit.org) (CHT). We welcome and appreciate contributions, and support new developers to use the tools whenever possible. If you have an idea or a question we'd love to hear from you! The easiest ways to get in touch are by raising issues in the [Github repo](https://github.com/medic/cht-conf-test-harness/issues) or [joining our Slack channel](https://communityhealthtoolkit.org/slack). For more info check out our [contributor guidelines](CONTRIBUTING.md).
 
 ## Copyright
 


### PR DESCRIPTION
I figured I would take a shot at putting together a basic CONTRIBUTING guide for this repo.  It is loosely modeled after the [cht-core CONTRIBUTING.md](https://github.com/medic/cht-core/blob/master/CONTRIBUTING.md), but I tried to pare it down to just the basics and some instructions specific to `cht-conf-test-harness`.

Let me know what else you would like to include in here!

Closes #127