### PR TITLE
Reload page when clearing harness

### DIFF
--- a/src/harness.js
+++ b/src/harness.js
@@ -168,7 +168,12 @@ class Harness {
    */
   async clear() {
     clearSync(this);
-    return this.page && await this.page.evaluate(() => window.restoreTimers());
+    if(!this.page) {
+      return Promise.resolve();
+    }
+
+    await this.page.reload();
+    return await this.page.evaluate(() => window.restoreTimers());
   }
 
   /**


### PR DESCRIPTION
Updates the `harness.clear()` function to also reload the page.

This is to prevent previous form data from remaining on the page between form submissions.

See [`#11`](https://github.com/orgs/medic/projects/120/views/1) for more information.